### PR TITLE
Alter line 5 of _includes/header.html to call secure typekit link.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <meta name="viewport" content="width = device-width, initial-scale =1 .0">
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
   <head>
-    <script type="text/javascript" src="http://use.typekit.com/wlg1psd.js"></script>
+    <script type="text/javascript" src="https://use.typekit.com/wlg1psd.js"></script>
     <script type="text/javascript">try{Typekit.load();}catch(e){}</script>  
     <link href="/css/screen.css" media="all" rel="stylesheet" type="text/css">
     <link href="/css/desktop.css" media="all" rel="stylesheet" type="text/css">


### PR DESCRIPTION
This makes it so that we are able to load the typekit link. Without the https:// protocol in the typekit link we aren't allowed to load it because juyinjudylee.com is secure, and http:// isn't.