### PR TITLE
Remove unneccessary spaces from header.html in includes.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <html>
-  <meta name="viewport" content="width = device-width, initial-scale =1 .0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
   <head>
     <script type="text/javascript" src="https://use.typekit.com/wlg1psd.js"></script>


### PR DESCRIPTION
<img width="1277" alt="Screen Shot 2021-07-29 at 11 36 01 AM" src="https://user-images.githubusercontent.com/66560552/127521739-bd0f6837-ddfa-4e59-8f7d-2331b4ed5897.png">
This was the error popping up on the live site.

In our viewport tag, where our `1.0` was we accidentally had `1 .0`. Dumb mistake! This fixes that.