### PR TITLE
Remove horizontal scroll from <html> and <body>.

### DIFF
--- a/css/screen.scss
+++ b/css/screen.scss
@@ -7,11 +7,12 @@
 }
 
 /* reset */
-html {margin:0;padding:0;border:0;}
+html {margin:0;padding:0;border:0;overflow-x:hidden;}
 body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, address, code, del, dfn, em, img, q, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, dialog, figure, footer, header, hgroup, nav, section {margin:0;padding:0;border:0;font-size:100%;font:inherit;vertical-align:baseline;}
 ul, li {margin:0;padding:0;list-style: none}
 
 body {
+  overflow-x: hidden;
   font-family: "museo-sans", "Helvetica Neue", Helvetica, sans-serif;
   background-color: #f9f9f9;
   color: #333;


### PR DESCRIPTION
Cleanliness. Plus, horizontal scroll can mess things up because it adds some extra to the site's sides.